### PR TITLE
fix: restrict numpy version to avoid incompatibility-caused error

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ install_requires =
     tensorflow
     seaborn
     cvxpy
+    numpy < 2.0.0
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
`numpy` whose version is more than or equal to 2.0.0 complains `ValueError: numpy.dtype size changed, may indicate binary incompatibility. `, which causes failure of `from isf.core.intersectional_fairness import IntersectionalFairness`.
One method to address it is to restrict the version of numpy to be installed to less than 2.0.0.
This pull request does that.