### PR TITLE
Make ipynb python-version agnostic

### DIFF
--- a/examples/tutorial.ipynb
+++ b/examples/tutorial.ipynb
@@ -33,7 +33,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib inline"
+    "%matplotlib inline\n"
    ]
   },
   {
@@ -43,7 +43,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pylab import rcParams"
+    "from pylab import rcParams\n"
    ]
   },
   {
@@ -56,7 +56,7 @@
     "from isf.core.intersectional_fairness import IntersectionalFairness\n",
     "from isf.utils.common import output_subgroup_metrics, convert_labels, create_multi_group_label\n",
     "from isf.analysis.intersectional_bias import calc_intersectionalbias, plot_intersectionalbias_compare\n",
-    "from isf.analysis.metrics import check_metrics_combination_attribute, check_metrics_single_attribute"
+    "from isf.analysis.metrics import check_metrics_combination_attribute, check_metrics_single_attribute\n"
    ]
   },
   {
@@ -67,7 +67,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "import pandas as pd"
+    "import pandas as pd\n"
    ]
   },
   {
@@ -98,7 +98,7 @@
     }
    ],
    "source": [
-    "!curl -O https://archive.ics.uci.edu/ml/machine-learning-databases/adult/adult.data"
+    "!curl -O https://archive.ics.uci.edu/ml/machine-learning-databases/adult/adult.data\n"
    ]
   },
   {
@@ -118,7 +118,7 @@
     }
    ],
    "source": [
-    "!curl -O https://archive.ics.uci.edu/ml/machine-learning-databases/adult/adult.test"
+    "!curl -O https://archive.ics.uci.edu/ml/machine-learning-databases/adult/adult.test\n"
    ]
   },
   {
@@ -138,7 +138,7 @@
     }
    ],
    "source": [
-    "!curl -O https://archive.ics.uci.edu/ml/machine-learning-databases/adult/adult.names"
+    "!curl -O https://archive.ics.uci.edu/ml/machine-learning-databases/adult/adult.names\n"
    ]
   },
   {
@@ -148,7 +148,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!mv adult* /usr/local/lib/python3.7/dist-packages/aif360/data/raw/adult"
+    "!mv adult* /usr/local/lib/python3.7/dist-packages/aif360/data/raw/adult\n"
    ]
   },
   {
@@ -158,7 +158,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from aif360.datasets import AdultDataset"
+    "from aif360.datasets import AdultDataset\n"
    ]
   },
   {
@@ -178,7 +178,7 @@
    "source": [
     "dataset = AdultDataset()\n",
     "convert_labels(dataset)\n",
-    "ds_train, ds_test = dataset.split([0.7])"
+    "ds_train, ds_test = dataset.split([0.7])\n"
    ]
   },
   {
@@ -210,7 +210,7 @@
     }
    ],
    "source": [
-    "dataset.protected_attribute_names"
+    "dataset.protected_attribute_names\n"
    ]
   },
   {
@@ -237,7 +237,7 @@
     "X_train = scale_orig.fit_transform(ds_train.features)\n",
     "y_train = ds_train.labels.ravel()\n",
     "X_test = scale_orig.transform(ds_test.features)\n",
-    "Y_test = ds_test.labels.ravel()"
+    "Y_test = ds_test.labels.ravel()\n"
    ]
   },
   {
@@ -261,7 +261,7 @@
     "from sklearn.linear_model import LogisticRegression\n",
     "\n",
     "lr = LogisticRegression()\n",
-    "lr.fit(X_train, y_train)"
+    "lr.fit(X_train, y_train)\n"
    ]
   },
   {
@@ -275,7 +275,7 @@
     "pos_ind = np.where(lr.classes_ == ds_train.favorable_label)[0][0]\n",
     "\n",
     "ds_test_classified.scores = lr.predict_proba(X_test)[:, pos_ind].reshape(-1, 1)\n",
-    "ds_test_classified.labels = lr.predict(X_test).reshape(-1, 1)"
+    "ds_test_classified.labels = lr.predict(X_test).reshape(-1, 1)\n"
    ]
   },
   {
@@ -290,7 +290,7 @@
     "pos_ind = np.where(lr.classes_ == ds_train.favorable_label)[0][0]\n",
     "\n",
     "ds_train_classified.scores = lr.predict_proba(X_train)[:, pos_ind].reshape(-1, 1)\n",
-    "ds_train_classified.labels = lr.predict(X_train).reshape(-1, 1)"
+    "ds_train_classified.labels = lr.predict(X_train).reshape(-1, 1)\n"
    ]
   },
   {
@@ -311,7 +311,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df_acc = pd.DataFrame(columns=['Accuracy','Precision','Recall','F1 score'])"
+    "df_acc = pd.DataFrame(columns=['Accuracy','Precision','Recall','F1 score'])\n"
    ]
   },
   {
@@ -325,7 +325,7 @@
     "df_acc.loc['LR Model']=( accuracy_score(y_true=Y_test, y_pred=ds_test_classified.labels),\n",
     "                   precision_score(y_true=Y_test, y_pred=ds_test_classified.labels),\n",
     "                   recall_score(y_true=Y_test, y_pred=ds_test_classified.labels),\n",
-    "                   f1_score(y_true=Y_test, y_pred=ds_test_classified.labels) )"
+    "                   f1_score(y_true=Y_test, y_pred=ds_test_classified.labels) )\n"
    ]
   },
   {
@@ -384,7 +384,7 @@
     }
    ],
    "source": [
-    "df_acc"
+    "df_acc\n"
    ]
   },
   {
@@ -473,7 +473,7 @@
    "source": [
     "df_lr_di = calc_intersectionalbias(ds_test_classified, \"DispareteImpact\")\n",
     "df_lr_di = df_lr_di.rename(columns={\"DispareteImpact\": \"LR Model\"})\n",
-    "df_lr_di"
+    "df_lr_di\n"
    ]
   },
   {
@@ -507,7 +507,7 @@
    "outputs": [],
    "source": [
     "ID = IntersectionalFairness('RejectOptionClassification', 'DemographicParity', \n",
-    "                             accuracy_metric='F1', options={'accuracy_metric_name':'F1', 'metric_ub':0.2, 'metric_lb':-0.2})"
+    "                             accuracy_metric='F1', options={'accuracy_metric_name':'F1', 'metric_ub':0.2, 'metric_lb':-0.2})\n"
    ]
   },
   {
@@ -529,7 +529,7 @@
    ],
    "source": [
     "# training\n",
-    "ID.fit(ds_train, dataset_predicted=ds_train_classified)"
+    "ID.fit(ds_train, dataset_predicted=ds_train_classified)\n"
    ]
   },
   {
@@ -551,7 +551,7 @@
    ],
    "source": [
     "# predict\n",
-    "ds_predicted = ID.predict(ds_test_classified)"
+    "ds_predicted = ID.predict(ds_test_classified)\n"
    ]
   },
   {
@@ -580,7 +580,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "combattr_metrics_isf = check_metrics_combination_attribute(ds_test, ds_predicted)[['base_rate', 'selection_rate', 'Balanced_Accuracy']]"
+    "combattr_metrics_isf = check_metrics_combination_attribute(ds_test, ds_predicted)[['base_rate', 'selection_rate', 'Balanced_Accuracy']]\n"
    ]
   },
   {
@@ -607,7 +607,7 @@
     "plot_intersectionalbias_compare(ds_test_classified,\n",
     "                                ds_predicted,\n",
     "                                vmax=2, vmin=0, center=1,\n",
-    "                                title={\"right\": \"LR Model\", \"left\": \"ISF(ROC is used)\"})"
+    "                                title={\"right\": \"LR Model\", \"left\": \"ISF(ROC is used)\"})\n"
    ]
   },
   {
@@ -640,7 +640,7 @@
     "df_acc.loc['ISF(ROC is used)']=( accuracy_score(y_true=Y_test, y_pred=ds_predicted.labels),\n",
     "                   precision_score(y_true=Y_test, y_pred=ds_predicted.labels),\n",
     "                   recall_score(y_true=Y_test, y_pred=ds_predicted.labels),\n",
-    "                   f1_score(y_true=Y_test, y_pred=ds_predicted.labels) )"
+    "                   f1_score(y_true=Y_test, y_pred=ds_predicted.labels) )\n"
    ]
   },
   {
@@ -707,7 +707,7 @@
     }
    ],
    "source": [
-    "df_acc"
+    "df_acc\n"
    ]
   },
   {
@@ -750,7 +750,7 @@
     "            metric_name='Statistical parity difference',\n",
     "            metric_ub=0.2,\n",
     "            metric_lb=-0.2,\n",
-    "            accuracy_metric_name='Balanced Accuracy')"
+    "            accuracy_metric_name='Balanced Accuracy')\n"
    ]
   },
   {
@@ -763,7 +763,7 @@
     "# training\n",
     "ROC.fit(ds_train, ds_train_classified)\n",
     "# predict\n",
-    "ds_predicted_roc = ROC.predict(ds_test_classified)"
+    "ds_predicted_roc = ROC.predict(ds_test_classified)\n"
    ]
   },
   {
@@ -848,7 +848,7 @@
     "df_roc_di =calc_intersectionalbias(ds_predicted_roc, \"DispareteImpact\")\n",
     "df_roc_di = df_roc_di.rename(columns={\"DispareteImpact\": \"ROC\"})\n",
     "df_lr_di[\"ROC\"]=df_roc_di[\"ROC\"]\n",
-    "df_lr_di"
+    "df_lr_di\n"
    ]
   },
   {
@@ -891,7 +891,7 @@
     "plot_intersectionalbias_compare(ds_predicted_roc,\n",
     "                                ds_predicted,\n",
     "                                vmax=2, vmin=0, center=1,\n",
-    "                                title={\"right\": \"RoC\", \"left\": \"ISF(used RoC)\"})"
+    "                                title={\"right\": \"RoC\", \"left\": \"ISF(used RoC)\"})\n"
    ]
   },
   {
@@ -924,7 +924,7 @@
     "df_acc.loc['ROC']=( accuracy_score(y_true=Y_test, y_pred=ds_predicted_roc.labels),\n",
     "                   precision_score(y_true=Y_test, y_pred=ds_predicted_roc.labels),\n",
     "                   recall_score(y_true=Y_test, y_pred=ds_predicted_roc.labels),\n",
-    "                   f1_score(y_true=Y_test, y_pred=ds_predicted_roc.labels) )"
+    "                   f1_score(y_true=Y_test, y_pred=ds_predicted_roc.labels) )\n"
    ]
   },
   {
@@ -999,7 +999,7 @@
     }
    ],
    "source": [
-    "df_acc"
+    "df_acc\n"
    ]
   },
   {

--- a/examples/tutorial.ipynb
+++ b/examples/tutorial.ipynb
@@ -148,7 +148,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!mv adult* /usr/local/lib/python3.7/dist-packages/aif360/data/raw/adult\n"
+    "# mv adult* to data/raw/adult in aif360 package\n",
+    "from pathlib import Path\n",
+    "from utils import get_aif360_location, mv\n",
+    "mv('adult*', Path(get_aif360_location(), 'data/raw/adult'))\n"
    ]
   },
   {

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -1,0 +1,24 @@
+from typing import Optional, Union
+import sys
+from pathlib import Path
+
+
+def get_aif360_location() -> Optional[str]:
+    for d in sys.path:
+        location = Path(d, 'aif360')
+        if location.exists() and location.is_dir():
+            return str(location)
+
+
+def mv(files_to_move: str, destination: Union[str, Path]):
+    dest_path = Path(destination)
+    if not dest_path.exists() or not dest_path.is_dir():
+        return
+    if files_to_move.startswith('/'):
+        top = '/'
+        rest = files_to_move[1:]
+    else:
+        top = '.'
+        rest = files_to_move
+    for f in Path(top).glob(rest):
+        Path(f).rename(Path(destination, Path(f).name))


### PR DESCRIPTION
`examples/tutorial.ipynb` works with only version 3.7 of python because of the line `!mv adult* /usr/local/lib/python3.7/dist-packages/aif360/data/raw/adult`.
This pull request replaces this line with the code to detect the destination directory to which to copy files `adult*` before copying.
Please look into the commit https://github.com/intersectional-fairness/isf/pull/14/commits/52247756cd45e3ae1547fa02bc7ca0dc70947430. Another commit contains no valuable changes.