### PR TITLE
Rewrite the code to assign a new value to an element in a DataFrame in the way that pandas warning message recommends

### DIFF
--- a/src/isf/core/intersectional_fairness.py
+++ b/src/isf/core/intersectional_fairness.py
@@ -774,9 +774,9 @@ class IntersectionalFairness():
         for i1 in range(len(dataset.instance_names)):
             idx = sortlist.get(dataset.instance_names[i1])
             if idx is not None:
-                disable_df['labels'][idx] = dataset.labels[i1]
-                disable_df['scores'][idx] = dataset.scores[i1]
-                disable_df['instance_weights'][idx] = dataset.instance_weights[i1]
+                disable_df.loc[idx, 'labels'] = dataset.labels[i1]
+                disable_df.loc[idx, 'scores'] = dataset.scores[i1]
+                disable_df.loc[idx, 'instance_weights'] = dataset.instance_weights[i1]
 
         return enable_ds, disable_df
 


### PR DESCRIPTION
The current version's code modifies modifies the copied object rather than the target object intended to be changed.
The code also causes the pandas library to emit many warning messages.
